### PR TITLE
Add GitHub Action to build PS4 homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: orbisdev/orbisdev:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile
+        run: orbis-clang main.c -o fake_shell.elf
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: fake_shell
+          path: fake_shell.elf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-Hi
+# PSHome
+
+This repository contains a simple PS4 homebrew example. The code can be compiled using the **orbisdev** toolchain.
+
+## Building locally
+
+Install the [orbisdev](https://github.com/orbisdev/orbisdev) toolchain and run:
+
+```sh
+orbis-clang main.c -o fake_shell.elf
+```
+
+## GitHub Actions
+
+A GitHub Actions workflow is provided to automatically build the project. It uses the `orbisdev/orbisdev` Docker image to compile `main.c` and uploads the resulting `fake_shell.elf` artifact.


### PR DESCRIPTION
## Summary
- configure GitHub Actions workflow to compile `main.c` using the orbisdev container
- document local build instructions and GitHub Actions usage in README

## Testing
- `gcc -c main.c` *(fails: `orbis/libkernel.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b3007744832aabf7a2595aada26f